### PR TITLE
feat: add audio format conversion (m4a, mp3, wav, ogg, aac, flac)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,21 +61,21 @@ bunx cap sync
 
 ## Supported today
 
-| Capability         | iOS             | Android | Web | Notes                                                                                                       |
-| ------------------ | --------------- | ------- | --- | ----------------------------------------------------------------------------------------------------------- |
-| `getCapabilities`  | ✅              | ✅      | ✅  | Returns the runtime capability matrix so apps can check what is actually usable on the current platform.    |
-| `getPluginVersion` | ✅              | ✅      | ✅  | Returns a `{ version }` payload on every platform; use `getCapabilities().platform` for platform detection. |
-| `reencodeVideo`    | ⚠️ Experimental | ❌      | ❌  | iOS accepts a queued job and reports lifecycle via `progress`; Android and web reject with `UNIMPLEMENTED`. |
-| `convertImage`     | ✅              | ✅      | ❌  | iOS converts still images to `jpeg` or `png`; Android converts to `webp`, `jpeg`, or `png`; web rejects.    |
-| `convertAudio`     | ✅              | ❌      | ❌  | iOS converts audio to `m4a`; Android and web reject with `UNIMPLEMENTED`.                                   |
+| Capability         | iOS             | Android         | Web | Notes                                                                                                                  |
+| ------------------ | --------------- | --------------- | --- | ---------------------------------------------------------------------------------------------------------------------- |
+| `getCapabilities`  | ✅              | ✅              | ✅  | Returns the runtime capability matrix so apps can check what is actually usable on the current platform.               |
+| `getPluginVersion` | ✅              | ✅              | ✅  | Returns a `{ version }` payload on every platform; use `getCapabilities().platform` for platform detection.            |
+| `reencodeVideo`    | ⚠️ Experimental | ⚠️ Experimental | ❌  | iOS and Android accept a queued job and report lifecycle via `progress`; web rejects with `UNIMPLEMENTED`.             |
+| `convertImage`     | ✅              | ✅              | ❌  | iOS converts still images to `jpeg` or `png`; Android converts to `webp`, `jpeg`, or `png`; web rejects.               |
+| `convertAudio`     | ✅              | ✅              | ❌  | iOS converts audio to `m4a` and `wav`; Android converts to `m4a`, `mp3`, `wav`, `ogg`, `aac`, and `flac`; web rejects. |
 
 ## Platform status
 
-| Platform | Status                        | Notes                                                                                                      |
-| -------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| iOS      | Early implementation          | Current reference platform for media work.                                                                 |
-| Android  | Partial native implementation | `convertImage` is native; the broader FFmpeg media engine and `convertAudio` still need to be implemented. |
-| Web      | Stub only                     | Media operations are intentionally unsupported right now.                                                  |
+| Platform | Status                        | Notes                                                                                                                    |
+| -------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| iOS      | Early implementation          | Current reference platform for media work.                                                                               |
+| Android  | Partial native implementation | `convertImage`, `convertAudio`, and `reencodeVideo` are native; broader FFmpeg media engine parity is still in progress. |
+| Web      | Stub only                     | Media operations are intentionally unsupported right now.                                                                |
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ bunx cap sync
 
 <docgen-index>
 
-* [`getCapabilities()`](#getcapabilities)
-* [`reencodeVideo(...)`](#reencodevideo)
-* [`convertImage(...)`](#convertimage)
-* [`convertAudio(...)`](#convertaudio)
-* [`addListener('progress', ...)`](#addlistenerprogress-)
-* [`getPluginVersion()`](#getpluginversion)
-* [Interfaces](#interfaces)
-* [Type Aliases](#type-aliases)
+- [`getCapabilities()`](#getcapabilities)
+- [`reencodeVideo(...)`](#reencodevideo)
+- [`convertImage(...)`](#convertimage)
+- [`convertAudio(...)`](#convertaudio)
+- [`addListener('progress', ...)`](#addlistenerprogress-)
+- [`getPluginVersion()`](#getpluginversion)
+- [Interfaces](#interfaces)
+- [Type Aliases](#type-aliases)
 
 </docgen-index>
 
@@ -105,8 +105,7 @@ Return the machine-readable capability matrix for the current platform.
 
 **Returns:** <code>Promise&lt;<a href="#ffmpegcapabilitiesresult">FFmpegCapabilitiesResult</a>&gt;</code>
 
---------------------
-
+---
 
 ### reencodeVideo(...)
 
@@ -128,8 +127,7 @@ Web currently rejects with `UNIMPLEMENTED`.
 
 **Returns:** <code>Promise&lt;<a href="#ffmpegacceptedjob">FFmpegAcceptedJob</a>&gt;</code>
 
---------------------
-
+---
 
 ### convertImage(...)
 
@@ -149,8 +147,7 @@ Web currently rejects with `UNIMPLEMENTED`.
 
 **Returns:** <code>Promise&lt;<a href="#convertimageresult">ConvertImageResult</a>&gt;</code>
 
---------------------
-
+---
 
 ### convertAudio(...)
 
@@ -170,8 +167,7 @@ Web currently rejects with `UNIMPLEMENTED`.
 
 **Returns:** <code>Promise&lt;<a href="#convertaudioresult">ConvertAudioResult</a>&gt;</code>
 
---------------------
-
+---
 
 ### addListener('progress', ...)
 
@@ -188,8 +184,7 @@ Listen for media job progress.
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
 
---------------------
-
+---
 
 ### getPluginVersion()
 
@@ -201,11 +196,9 @@ Get the plugin package version reported by the current platform implementation.
 
 **Returns:** <code>Promise&lt;<a href="#pluginversionresult">PluginVersionResult</a>&gt;</code>
 
---------------------
-
+---
 
 ### Interfaces
-
 
 #### FFmpegCapabilitiesResult
 
@@ -213,7 +206,6 @@ Get the plugin package version reported by the current platform implementation.
 | -------------- | --------------------------------------------------------------------------------- |
 | **`platform`** | <code>string</code>                                                               |
 | **`features`** | <code><a href="#ffmpegcapabilitiesfeatures">FFmpegCapabilitiesFeatures</a></code> |
-
 
 #### FFmpegCapabilitiesFeatures
 
@@ -231,7 +223,6 @@ Get the plugin package version reported by the current platform implementation.
 | **`remux`**             | <code><a href="#ffmpegcapability">FFmpegCapability</a></code> |
 | **`trim`**              | <code><a href="#ffmpegcapability">FFmpegCapability</a></code> |
 
-
 #### FFmpegCapability
 
 | Prop         | Type                                                                      |
@@ -239,14 +230,12 @@ Get the plugin package version reported by the current platform implementation.
 | **`status`** | <code><a href="#ffmpegcapabilitystatus">FFmpegCapabilityStatus</a></code> |
 | **`reason`** | <code>string</code>                                                       |
 
-
 #### FFmpegAcceptedJob
 
 | Prop         | Type                  |
 | ------------ | --------------------- |
 | **`jobId`**  | <code>string</code>   |
 | **`status`** | <code>'queued'</code> |
-
 
 #### ReencodeVideoOptions
 
@@ -258,14 +247,12 @@ Get the plugin package version reported by the current platform implementation.
 | **`height`**     | <code>number</code> |
 | **`bitrate`**    | <code>number</code> |
 
-
 #### ConvertImageResult
 
 | Prop             | Type                                                            |
 | ---------------- | --------------------------------------------------------------- |
 | **`outputPath`** | <code>string</code>                                             |
 | **`format`**     | <code><a href="#imageoutputformat">ImageOutputFormat</a></code> |
-
 
 #### ConvertImageOptions
 
@@ -276,14 +263,12 @@ Get the plugin package version reported by the current platform implementation.
 | **`format`**     | <code><a href="#imageoutputformat">ImageOutputFormat</a></code> |                                                                                                           |
 | **`quality`**    | <code>number</code>                                             | Compression quality in the inclusive range `0.0..1.0`. Native platforms reject values outside that range. |
 
-
 #### ConvertAudioResult
 
 | Prop             | Type                                                            |
 | ---------------- | --------------------------------------------------------------- |
 | **`outputPath`** | <code>string</code>                                             |
 | **`format`**     | <code><a href="#audiooutputformat">AudioOutputFormat</a></code> |
-
 
 #### ConvertAudioOptions
 
@@ -294,13 +279,11 @@ Get the plugin package version reported by the current platform implementation.
 | **`format`**     | <code><a href="#audiooutputformat">AudioOutputFormat</a></code> |                                                                                                 |
 | **`bitrate`**    | <code>number</code>                                             | Target audio bitrate in bits per second. Ignored for lossless outputs such as `wav` and `flac`. |
 
-
 #### PluginListenerHandle
 
 | Prop         | Type                                      |
 | ------------ | ----------------------------------------- |
 | **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
-
 
 #### FFmpegProgressEvent
 
@@ -313,31 +296,25 @@ Get the plugin package version reported by the current platform implementation.
 | **`outputPath`** | <code>string</code>                                                 |                                                                                  |
 | **`fileId`**     | <code>string</code>                                                 | Legacy alias kept for compatibility while callers migrate to `jobId`.            |
 
-
 #### PluginVersionResult
 
 | Prop          | Type                |
 | ------------- | ------------------- |
 | **`version`** | <code>string</code> |
 
-
 ### Type Aliases
-
 
 #### FFmpegCapabilityStatus
 
 <code>'available' | 'experimental' | 'unimplemented' | 'unavailable'</code>
 
-
 #### ImageOutputFormat
 
 <code>'webp' | 'jpeg' | 'png'</code>
 
-
 #### AudioOutputFormat
 
 <code>'m4a' | 'mp3' | 'wav' | 'ogg' | 'aac' | 'flac'</code>
-
 
 #### FFmpegProgressState
 

--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ bunx cap sync
 
 <docgen-index>
 
-* [`getCapabilities()`](#getcapabilities)
-* [`reencodeVideo(...)`](#reencodevideo)
-* [`convertImage(...)`](#convertimage)
-* [`convertAudio(...)`](#convertaudio)
-* [`addListener('progress', ...)`](#addlistenerprogress-)
-* [`getPluginVersion()`](#getpluginversion)
-* [Interfaces](#interfaces)
-* [Type Aliases](#type-aliases)
+- [`getCapabilities()`](#getcapabilities)
+- [`reencodeVideo(...)`](#reencodevideo)
+- [`convertImage(...)`](#convertimage)
+- [`convertAudio(...)`](#convertaudio)
+- [`addListener('progress', ...)`](#addlistenerprogress-)
+- [`getPluginVersion()`](#getpluginversion)
+- [Interfaces](#interfaces)
+- [Type Aliases](#type-aliases)
 
 </docgen-index>
 
@@ -105,8 +105,7 @@ Return the machine-readable capability matrix for the current platform.
 
 **Returns:** <code>Promise&lt;<a href="#ffmpegcapabilitiesresult">FFmpegCapabilitiesResult</a>&gt;</code>
 
---------------------
-
+---
 
 ### reencodeVideo(...)
 
@@ -127,8 +126,7 @@ Android and web currently reject with `UNIMPLEMENTED`.
 
 **Returns:** <code>Promise&lt;<a href="#ffmpegacceptedjob">FFmpegAcceptedJob</a>&gt;</code>
 
---------------------
-
+---
 
 ### convertImage(...)
 
@@ -148,8 +146,7 @@ Web currently rejects with `UNIMPLEMENTED`.
 
 **Returns:** <code>Promise&lt;<a href="#convertimageresult">ConvertImageResult</a>&gt;</code>
 
---------------------
-
+---
 
 ### convertAudio(...)
 
@@ -159,8 +156,9 @@ convertAudio(options: ConvertAudioOptions) => Promise<ConvertAudioResult>
 
 Convert audio into another container or codec.
 
-iOS currently supports `m4a`.
-Android and web currently reject with `UNIMPLEMENTED`.
+iOS currently supports `m4a` and `wav`.
+Android supports `m4a`, `mp3`, `wav`, `ogg`, `aac`, and `flac`.
+Web currently rejects with `UNIMPLEMENTED`.
 
 | Param         | Type                                                                |
 | ------------- | ------------------------------------------------------------------- |
@@ -168,8 +166,7 @@ Android and web currently reject with `UNIMPLEMENTED`.
 
 **Returns:** <code>Promise&lt;<a href="#convertaudioresult">ConvertAudioResult</a>&gt;</code>
 
---------------------
-
+---
 
 ### addListener('progress', ...)
 
@@ -186,8 +183,7 @@ Listen for media job progress.
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
 
---------------------
-
+---
 
 ### getPluginVersion()
 
@@ -199,11 +195,9 @@ Get the plugin package version reported by the current platform implementation.
 
 **Returns:** <code>Promise&lt;<a href="#pluginversionresult">PluginVersionResult</a>&gt;</code>
 
---------------------
-
+---
 
 ### Interfaces
-
 
 #### FFmpegCapabilitiesResult
 
@@ -211,7 +205,6 @@ Get the plugin package version reported by the current platform implementation.
 | -------------- | --------------------------------------------------------------------------------- |
 | **`platform`** | <code>string</code>                                                               |
 | **`features`** | <code><a href="#ffmpegcapabilitiesfeatures">FFmpegCapabilitiesFeatures</a></code> |
-
 
 #### FFmpegCapabilitiesFeatures
 
@@ -229,7 +222,6 @@ Get the plugin package version reported by the current platform implementation.
 | **`remux`**             | <code><a href="#ffmpegcapability">FFmpegCapability</a></code> |
 | **`trim`**              | <code><a href="#ffmpegcapability">FFmpegCapability</a></code> |
 
-
 #### FFmpegCapability
 
 | Prop         | Type                                                                      |
@@ -237,14 +229,12 @@ Get the plugin package version reported by the current platform implementation.
 | **`status`** | <code><a href="#ffmpegcapabilitystatus">FFmpegCapabilityStatus</a></code> |
 | **`reason`** | <code>string</code>                                                       |
 
-
 #### FFmpegAcceptedJob
 
 | Prop         | Type                  |
 | ------------ | --------------------- |
 | **`jobId`**  | <code>string</code>   |
 | **`status`** | <code>'queued'</code> |
-
 
 #### ReencodeVideoOptions
 
@@ -256,14 +246,12 @@ Get the plugin package version reported by the current platform implementation.
 | **`height`**     | <code>number</code> |
 | **`bitrate`**    | <code>number</code> |
 
-
 #### ConvertImageResult
 
 | Prop             | Type                                                            |
 | ---------------- | --------------------------------------------------------------- |
 | **`outputPath`** | <code>string</code>                                             |
 | **`format`**     | <code><a href="#imageoutputformat">ImageOutputFormat</a></code> |
-
 
 #### ConvertImageOptions
 
@@ -274,7 +262,6 @@ Get the plugin package version reported by the current platform implementation.
 | **`format`**     | <code><a href="#imageoutputformat">ImageOutputFormat</a></code> |                                                                                                           |
 | **`quality`**    | <code>number</code>                                             | Compression quality in the inclusive range `0.0..1.0`. Native platforms reject values outside that range. |
 
-
 #### ConvertAudioResult
 
 | Prop             | Type                                                            |
@@ -282,22 +269,20 @@ Get the plugin package version reported by the current platform implementation.
 | **`outputPath`** | <code>string</code>                                             |
 | **`format`**     | <code><a href="#audiooutputformat">AudioOutputFormat</a></code> |
 
-
 #### ConvertAudioOptions
 
-| Prop             | Type                                                            |
-| ---------------- | --------------------------------------------------------------- |
-| **`inputPath`**  | <code>string</code>                                             |
-| **`outputPath`** | <code>string</code>                                             |
-| **`format`**     | <code><a href="#audiooutputformat">AudioOutputFormat</a></code> |
-
+| Prop             | Type                                                            | Description                                                                                     |
+| ---------------- | --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| **`inputPath`**  | <code>string</code>                                             |                                                                                                 |
+| **`outputPath`** | <code>string</code>                                             |                                                                                                 |
+| **`format`**     | <code><a href="#audiooutputformat">AudioOutputFormat</a></code> |                                                                                                 |
+| **`bitrate`**    | <code>number</code>                                             | Target audio bitrate in bits per second. Ignored for lossless outputs such as `wav` and `flac`. |
 
 #### PluginListenerHandle
 
 | Prop         | Type                                      |
 | ------------ | ----------------------------------------- |
 | **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
-
 
 #### FFmpegProgressEvent
 
@@ -310,31 +295,25 @@ Get the plugin package version reported by the current platform implementation.
 | **`outputPath`** | <code>string</code>                                                 |                                                                                  |
 | **`fileId`**     | <code>string</code>                                                 | Legacy alias kept for compatibility while callers migrate to `jobId`.            |
 
-
 #### PluginVersionResult
 
 | Prop          | Type                |
 | ------------- | ------------------- |
 | **`version`** | <code>string</code> |
 
-
 ### Type Aliases
-
 
 #### FFmpegCapabilityStatus
 
 <code>'available' | 'experimental' | 'unimplemented' | 'unavailable'</code>
 
-
 #### ImageOutputFormat
 
 <code>'webp' | 'jpeg' | 'png'</code>
 
-
 #### AudioOutputFormat
 
-<code>'m4a'</code>
-
+<code>'m4a' | 'mp3' | 'wav' | 'ogg' | 'aac' | 'flac'</code>
 
 #### FFmpegProgressState
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
+    implementation "com.moizhassan.ffmpeg:ffmpeg-kit-16kb:6.1.1"
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/android/src/main/java/ee/forgr/capacitor_ffmpeg/AndroidAudioConverter.java
+++ b/android/src/main/java/ee/forgr/capacitor_ffmpeg/AndroidAudioConverter.java
@@ -1,0 +1,102 @@
+package ee.forgr.capacitor_ffmpeg;
+
+import com.arthenica.ffmpegkit.FFmpegKit;
+import com.arthenica.ffmpegkit.FFmpegSession;
+import com.arthenica.ffmpegkit.ReturnCode;
+import java.io.File;
+import java.util.Locale;
+import java.util.Map;
+
+final class AndroidAudioConverter {
+
+    private static final Map<String, String> FORMAT_TO_CODEC = Map.of(
+        "m4a",
+        "aac",
+        "mp3",
+        "libmp3lame",
+        "wav",
+        "pcm_s16le",
+        "ogg",
+        "libvorbis",
+        "aac",
+        "aac",
+        "flac",
+        "flac"
+    );
+
+    ConvertedAudio convert(final File inputFile, final File outputFile, final String format, final Integer bitrate)
+        throws IllegalArgumentException, IllegalStateException {
+        final String normalizedFormat = normalizeAudioFormat(format);
+        final String codec = FORMAT_TO_CODEC.get(normalizedFormat);
+        if (codec == null) {
+            throw new IllegalArgumentException("Unsupported audio format: " + format);
+        }
+
+        final String extension = outputFile.getName();
+        final int dotIndex = extension.lastIndexOf('.');
+        if (dotIndex < 0 || !extension.substring(dotIndex + 1).equalsIgnoreCase(normalizedFormat)) {
+            throw new IllegalArgumentException("Output path extension must be ." + normalizedFormat + ".");
+        }
+
+        final StringBuilder command = new StringBuilder();
+        command.append("-y -i \"").append(inputFile.getAbsolutePath()).append("\" -vn -c:a ").append(codec);
+
+        if (bitrate != null && bitrate > 0 && !"wav".equals(normalizedFormat) && !"flac".equals(normalizedFormat)) {
+            command.append(" -b:a ").append(bitrate);
+        }
+
+        if ("m4a".equals(normalizedFormat)) {
+            command.append(" -movflags +faststart");
+        }
+
+        command.append(" \"").append(outputFile.getAbsolutePath()).append("\"");
+
+        final FFmpegSession session = FFmpegKit.execute(command.toString());
+        if (!ReturnCode.isSuccess(session.getReturnCode())) {
+            final String logs = session.getAllLogsAsString();
+            final String message = logs != null && !logs.isBlank() ? logs.trim() : "Could not convert the input audio.";
+            throw new IllegalStateException(message);
+        }
+
+        if (!outputFile.isFile()) {
+            throw new IllegalStateException("Converted audio was not created.");
+        }
+
+        return new ConvertedAudio(outputFile.getAbsolutePath(), normalizedFormat);
+    }
+
+    String normalizeAudioFormat(final String rawFormat) {
+        if (rawFormat == null || rawFormat.trim().isEmpty()) {
+            throw new IllegalArgumentException("An output audio format is required.");
+        }
+
+        return switch (rawFormat.trim().toLowerCase(Locale.ROOT)) {
+            case "m4a" -> "m4a";
+            case "mp3" -> "mp3";
+            case "wav" -> "wav";
+            case "ogg" -> "ogg";
+            case "aac" -> "aac";
+            case "flac" -> "flac";
+            default -> throw new IllegalArgumentException("Unsupported audio format: " + rawFormat);
+        };
+    }
+
+    static final class ConvertedAudio {
+
+        private final String outputPath;
+        private final String format;
+
+        ConvertedAudio(final String outputPath, final String format) {
+            this.outputPath = outputPath;
+            this.format = format;
+        }
+
+        String getOutputPath() {
+            return outputPath;
+        }
+
+        String getFormat() {
+            return format;
+        }
+    }
+}

--- a/android/src/main/java/ee/forgr/capacitor_ffmpeg/AndroidAudioConverter.java
+++ b/android/src/main/java/ee/forgr/capacitor_ffmpeg/AndroidAudioConverter.java
@@ -4,6 +4,8 @@ import com.arthenica.ffmpegkit.FFmpegKit;
 import com.arthenica.ffmpegkit.FFmpegSession;
 import com.arthenica.ffmpegkit.ReturnCode;
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -38,20 +40,27 @@ final class AndroidAudioConverter {
             throw new IllegalArgumentException("Output path extension must be ." + normalizedFormat + ".");
         }
 
-        final StringBuilder command = new StringBuilder();
-        command.append("-y -i \"").append(inputFile.getAbsolutePath()).append("\" -vn -c:a ").append(codec);
+        final List<String> arguments = new ArrayList<>();
+        arguments.add("-y");
+        arguments.add("-i");
+        arguments.add(inputFile.getAbsolutePath());
+        arguments.add("-vn");
+        arguments.add("-c:a");
+        arguments.add(codec);
 
         if (bitrate != null && bitrate > 0 && !"wav".equals(normalizedFormat) && !"flac".equals(normalizedFormat)) {
-            command.append(" -b:a ").append(bitrate);
+            arguments.add("-b:a");
+            arguments.add(String.valueOf(bitrate));
         }
 
         if ("m4a".equals(normalizedFormat)) {
-            command.append(" -movflags +faststart");
+            arguments.add("-movflags");
+            arguments.add("+faststart");
         }
 
-        command.append(" \"").append(outputFile.getAbsolutePath()).append("\"");
+        arguments.add(outputFile.getAbsolutePath());
 
-        final FFmpegSession session = FFmpegKit.execute(command.toString());
+        final FFmpegSession session = FFmpegKit.executeWithArguments(arguments.toArray(new String[0]));
         if (!ReturnCode.isSuccess(session.getReturnCode())) {
             final String logs = session.getAllLogsAsString();
             final String message = logs != null && !logs.isBlank() ? logs.trim() : "Could not convert the input audio.";

--- a/android/src/main/java/ee/forgr/capacitor_ffmpeg/CapacitorFFmpegPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_ffmpeg/CapacitorFFmpegPlugin.java
@@ -202,6 +202,11 @@ public class CapacitorFFmpegPlugin extends Plugin {
         final String format = call.getString("format");
         final Integer bitrate = call.getInt("bitrate");
 
+        if (bitrate != null && bitrate < 0) {
+            call.reject("Bitrate must be greater than or equal to 0", "INVALID_ARGUMENT");
+            return;
+        }
+
         try {
             final File inputFile = resolveFilesystemPath(inputPath);
             final File outputFile = resolveFilesystemPath(outputPath);

--- a/android/src/main/java/ee/forgr/capacitor_ffmpeg/CapacitorFFmpegPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_ffmpeg/CapacitorFFmpegPlugin.java
@@ -18,6 +18,8 @@ import java.util.Locale;
 @CapacitorPlugin(name = "CapacitorFFmpeg")
 public class CapacitorFFmpegPlugin extends Plugin {
 
+    private final AndroidAudioConverter audioConverter = new AndroidAudioConverter();
+
     @PluginMethod
     public void getCapabilities(final PluginCall call) {
         try {
@@ -92,7 +94,38 @@ public class CapacitorFFmpegPlugin extends Plugin {
 
     @PluginMethod
     public void convertAudio(final PluginCall call) {
-        call.unimplemented(getUnsupportedOperationMessage("convertAudio"));
+        final String inputPath = call.getString("inputPath");
+        final String outputPath = call.getString("outputPath");
+        final String format = call.getString("format");
+        final Integer bitrate = call.getInt("bitrate");
+
+        try {
+            final File inputFile = resolveFilesystemPath(inputPath);
+            final File outputFile = resolveFilesystemPath(outputPath);
+
+            if (!inputFile.isFile()) {
+                call.reject("Input audio not found: " + inputFile.getAbsolutePath(), "INVALID_ARGUMENT");
+                return;
+            }
+
+            if (inputFile.getCanonicalFile().equals(outputFile.getCanonicalFile())) {
+                call.reject("In-place conversion is not allowed. Choose a different output path.", "INVALID_ARGUMENT");
+                return;
+            }
+
+            final AndroidAudioConverter.ConvertedAudio convertedAudio = audioConverter.convert(inputFile, outputFile, format, bitrate);
+
+            final JSObject ret = new JSObject();
+            ret.put("outputPath", Uri.fromFile(new File(convertedAudio.getOutputPath())).toString());
+            ret.put("format", convertedAudio.getFormat());
+            call.resolve(ret);
+        } catch (final IllegalArgumentException exception) {
+            call.reject(exception.getMessage(), "INVALID_ARGUMENT", exception);
+        } catch (final IllegalStateException exception) {
+            call.reject(exception.getMessage(), "TRANSCODE_FAILED", exception);
+        } catch (final IOException exception) {
+            call.reject("Could not convert audio", "TRANSCODE_FAILED", exception);
+        }
     }
 
     @PluginMethod
@@ -156,7 +189,7 @@ public class CapacitorFFmpegPlugin extends Plugin {
             case "getPluginVersion", "getCapabilities" -> "available";
             case "reencodeVideo" -> "unimplemented";
             case "convertImage" -> "available";
-            case "convertAudio" -> "unimplemented";
+            case "convertAudio" -> "available";
             case "progressEvents" -> "unavailable";
             case "probeMedia", "generateThumbnail", "extractAudio", "remux", "trim" -> "unimplemented";
             default -> "unimplemented";
@@ -167,7 +200,7 @@ public class CapacitorFFmpegPlugin extends Plugin {
         return switch (feature) {
             case "reencodeVideo" -> getUnsupportedOperationMessage("reencodeVideo");
             case "convertImage" -> "Still-image conversion is available on Android for webp, jpeg, and png outputs.";
-            case "convertAudio" -> getUnsupportedOperationMessage("convertAudio");
+            case "convertAudio" -> "Audio conversion is available on Android for m4a, mp3, wav, ogg, aac, and flac outputs.";
             case "progressEvents" -> "No media jobs are available on Android today.";
             case "probeMedia" -> "probeMedia is not implemented on Android.";
             case "generateThumbnail" -> "generateThumbnail is not implemented on Android.";

--- a/android/src/test/java/ee/forgr/capacitor_ffmpeg/CapacitorFFmpegPluginTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_ffmpeg/CapacitorFFmpegPluginTest.java
@@ -43,13 +43,16 @@ public class CapacitorFFmpegPluginTest {
         assertEquals("available", plugin.getCapabilityStatus("getCapabilities"));
         assertEquals("unimplemented", plugin.getCapabilityStatus("reencodeVideo"));
         assertEquals("available", plugin.getCapabilityStatus("convertImage"));
-        assertEquals("unimplemented", plugin.getCapabilityStatus("convertAudio"));
+        assertEquals("available", plugin.getCapabilityStatus("convertAudio"));
         assertEquals("reencodeVideo is currently only available on iOS.", plugin.getCapabilityReason("reencodeVideo"));
         assertEquals(
             "Still-image conversion is available on Android for webp, jpeg, and png outputs.",
             plugin.getCapabilityReason("convertImage")
         );
-        assertEquals("convertAudio is currently only available on iOS.", plugin.getCapabilityReason("convertAudio"));
+        assertEquals(
+            "Audio conversion is available on Android for m4a, mp3, wav, ogg, aac, and flac outputs.",
+            plugin.getCapabilityReason("convertAudio")
+        );
     }
 
     @Test
@@ -62,8 +65,11 @@ public class CapacitorFFmpegPluginTest {
         assertEquals("available", features.getJSONObject("getCapabilities").getString("status"));
         assertEquals("unimplemented", features.getJSONObject("reencodeVideo").getString("status"));
         assertEquals("reencodeVideo is currently only available on iOS.", features.getJSONObject("reencodeVideo").getString("reason"));
-        assertEquals("unimplemented", features.getJSONObject("convertAudio").getString("status"));
-        assertEquals("convertAudio is currently only available on iOS.", features.getJSONObject("convertAudio").getString("reason"));
+        assertEquals("available", features.getJSONObject("convertAudio").getString("status"));
+        assertEquals(
+            "Audio conversion is available on Android for m4a, mp3, wav, ogg, aac, and flac outputs.",
+            features.getJSONObject("convertAudio").getString("reason")
+        );
     }
 
     @Test
@@ -74,6 +80,14 @@ public class CapacitorFFmpegPluginTest {
         assertEquals("webp", plugin.normalizeImageFormat("webp"));
         assertEquals(85, plugin.resolveImageQuality(null));
         assertEquals(25, plugin.resolveImageQuality(0.25));
+    }
+
+    @Test
+    public void audioConversionHelpersNormalizeSupportedFormats() {
+        final AndroidAudioConverter converter = new AndroidAudioConverter();
+
+        assertEquals("mp3", converter.normalizeAudioFormat("MP3"));
+        assertEquals("flac", converter.normalizeAudioFormat("flac"));
     }
 
     @Test

--- a/ios/Sources/CapacitorFFmpegPlugin/CapacitorFFmpeg.swift
+++ b/ios/Sources/CapacitorFFmpegPlugin/CapacitorFFmpeg.swift
@@ -553,8 +553,8 @@ private final class SelfForReencodeVideo {
             throw FFmpegError.invalidArgument("Unsupported audio format: \(format)")
         }
 
-        guard outputURL.pathExtension.lowercased() == expectedExtension else {
-            throw FFmpegError.invalidArgument("Output path extension must be .\(expectedExtension).")
+        guard outputURL.pathExtension.lowercased() == normalizedFormat else {
+            throw FFmpegError.invalidArgument("Output path extension must be .\(normalizedFormat).")
         }
 
         let asset = AVURLAsset(url: inputURL)

--- a/ios/Sources/CapacitorFFmpegPlugin/CapacitorFFmpeg.swift
+++ b/ios/Sources/CapacitorFFmpegPlugin/CapacitorFFmpeg.swift
@@ -174,7 +174,7 @@ struct FFmpegCapabilitiesPayload {
                 ),
                 "convertAudio": FFmpegCapabilityPayload(
                     status: "available",
-                    reason: "Audio conversion is available on iOS for m4a output."
+                    reason: "Audio conversion is available on iOS for m4a and wav outputs."
                 ),
                 "progressEvents": FFmpegCapabilityPayload(
                     status: nativeCoreAvailable ? "available" : "unavailable",
@@ -534,11 +534,27 @@ private final class SelfForReencodeVideo {
             throw FFmpegError.invalidArgument("In-place conversion is not allowed. Choose a different output path.")
         }
 
-        guard normalizedFormat == "m4a" else {
+        let exportPreset: String
+        let exportFileType: AVFileType
+        let temporaryExtension: String
+
+        switch normalizedFormat {
+        case "m4a":
+            exportPreset = AVAssetExportPresetAppleM4A
+            exportFileType = .m4a
+            temporaryExtension = "m4a"
+        case "wav":
+            exportPreset = AVAssetExportPresetPassthrough
+            exportFileType = .wav
+            temporaryExtension = "wav"
+        case "mp3", "ogg", "flac", "aac":
+            throw FFmpegError.invalidArgument("Audio format \(format) is not yet supported on iOS.")
+        default:
             throw FFmpegError.invalidArgument("Unsupported audio format: \(format)")
         }
-        guard outputURL.pathExtension.lowercased() == normalizedFormat else {
-            throw FFmpegError.invalidArgument("Output path extension must be .\(normalizedFormat).")
+
+        guard outputURL.pathExtension.lowercased() == expectedExtension else {
+            throw FFmpegError.invalidArgument("Output path extension must be .\(expectedExtension).")
         }
 
         let asset = AVURLAsset(url: inputURL)
@@ -554,14 +570,14 @@ private final class SelfForReencodeVideo {
         )
         let temporaryOutputURL = outputDirectory
             .appendingPathComponent(".ffmpeg-audio-\(UUID().uuidString)")
-            .appendingPathExtension(outputURL.pathExtension.isEmpty ? "m4a" : outputURL.pathExtension)
+            .appendingPathExtension(outputURL.pathExtension.isEmpty ? temporaryExtension : outputURL.pathExtension)
 
-        guard let exportSession = audioExportSessionFactory(asset, AVAssetExportPresetAppleM4A) else {
+        guard let exportSession = audioExportSessionFactory(asset, exportPreset) else {
             throw FFmpegError.transcodeFailed("Could not create the audio export session.")
         }
 
         exportSession.outputURL = temporaryOutputURL
-        exportSession.outputFileType = .m4a
+        exportSession.outputFileType = exportFileType
 
         exportSession.exportAsynchronously {
             defer {

--- a/ios/Sources/CapacitorFFmpegPlugin/CapacitorFFmpeg.swift
+++ b/ios/Sources/CapacitorFFmpegPlugin/CapacitorFFmpeg.swift
@@ -544,9 +544,12 @@ private final class SelfForReencodeVideo {
             exportFileType = .m4a
             temporaryExtension = "m4a"
         case "wav":
-            exportPreset = AVAssetExportPresetPassthrough
-            exportFileType = .wav
-            temporaryExtension = "wav"
+            try transcodeAudioToWav(
+                asset: AVURLAsset(url: inputURL),
+                outputURL: outputURL,
+                completion: completion
+            )
+            return
         case "mp3", "ogg", "flac", "aac":
             throw FFmpegError.invalidArgument("Audio format \(format) is not yet supported on iOS.")
         default:
@@ -604,6 +607,133 @@ private final class SelfForReencodeVideo {
             } catch {
                 completion(.failure(error))
             }
+        }
+    }
+
+    private func transcodeAudioToWav(
+        asset: AVAsset,
+        outputURL: URL,
+        completion: @escaping AudioConversionCompletion
+    ) throws {
+        guard outputURL.pathExtension.lowercased() == "wav" else {
+            throw FFmpegError.invalidArgument("Output path extension must be .wav.")
+        }
+
+        guard !asset.tracks(withMediaType: .audio).isEmpty else {
+            throw FFmpegError.invalidArgument("The input media does not contain an audio track.")
+        }
+
+        let fileManager = FileManager.default
+        let outputDirectory = outputURL.deletingLastPathComponent()
+        try fileManager.createDirectory(
+            at: outputDirectory,
+            withIntermediateDirectories: true
+        )
+        let temporaryOutputURL = outputDirectory
+            .appendingPathComponent(".ffmpeg-audio-\(UUID().uuidString)")
+            .appendingPathExtension("wav")
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            defer {
+                try? fileManager.removeItem(at: temporaryOutputURL)
+            }
+
+            do {
+                try self.writePcmWav(from: asset, to: temporaryOutputURL)
+
+                if fileManager.fileExists(atPath: outputURL.path) {
+                    _ = try fileManager.replaceItemAt(outputURL, withItemAt: temporaryOutputURL)
+                } else {
+                    try fileManager.moveItem(at: temporaryOutputURL, to: outputURL)
+                }
+
+                completion(.success(FFmpegConvertedAudio(
+                    outputPath: outputURL.absoluteString,
+                    format: "wav"
+                )))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    private func writePcmWav(from asset: AVAsset, to outputURL: URL) throws {
+        guard let audioTrack = asset.tracks(withMediaType: .audio).first else {
+            throw FFmpegError.invalidArgument("The input media does not contain an audio track.")
+        }
+
+        let pcmOutputSettings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsFloatKey: false,
+            AVLinearPCMIsNonInterleaved: false
+        ]
+
+        let reader = try AVAssetReader(asset: asset)
+        let readerOutput = AVAssetReaderTrackOutput(track: audioTrack, outputSettings: pcmOutputSettings)
+        readerOutput.alwaysCopiesSampleData = false
+        reader.add(readerOutput)
+
+        let writer = try AVAssetWriter(outputURL: outputURL, fileType: .wav)
+        let writerInput = AVAssetWriterInput(mediaType: .audio, outputSettings: pcmOutputSettings)
+        writerInput.expectsMediaDataInRealTime = false
+        writer.add(writerInput)
+
+        guard reader.startReading() else {
+            throw FFmpegError.transcodeFailed(
+                reader.error?.localizedDescription ?? "Could not read the input audio."
+            )
+        }
+
+        guard writer.startWriting() else {
+            throw FFmpegError.transcodeFailed(
+                writer.error?.localizedDescription ?? "Could not create the output audio."
+            )
+        }
+
+        writer.startSession(atSourceTime: .zero)
+
+        let transcodeQueue = DispatchQueue(label: "capgo.ffmpeg.wav-transcode")
+        let transcodeGroup = DispatchGroup()
+        transcodeGroup.enter()
+
+        writerInput.requestMediaDataWhenReady(on: transcodeQueue) {
+            while writerInput.isReadyForMoreMediaData {
+                if let sampleBuffer = readerOutput.copyNextSampleBuffer() {
+                    if !writerInput.append(sampleBuffer) {
+                        reader.cancelReading()
+                        writer.cancelWriting()
+                        transcodeGroup.leave()
+                        return
+                    }
+                } else {
+                    writerInput.markAsFinished()
+                    transcodeGroup.leave()
+                    return
+                }
+            }
+        }
+
+        transcodeGroup.wait()
+
+        let finishGroup = DispatchGroup()
+        finishGroup.enter()
+        var finishError: Error?
+
+        writer.finishWriting {
+            finishError = writer.error
+            finishGroup.leave()
+        }
+
+        finishGroup.wait()
+
+        if let finishError {
+            throw finishError
+        }
+
+        guard writer.status == .completed else {
+            throw FFmpegError.transcodeFailed("Could not export the output audio.")
         }
     }
 

--- a/ios/Sources/CapacitorFFmpegPlugin/PluginVersion.generated.swift
+++ b/ios/Sources/CapacitorFFmpegPlugin/PluginVersion.generated.swift
@@ -1,3 +1,3 @@
 enum CapacitorFFmpegPluginVersion {
-    static let value = "0.0.10"
+    static let value = "0.0.11"
 }

--- a/ios/Sources/CapacitorFFmpegPlugin/PluginVersion.generated.swift
+++ b/ios/Sources/CapacitorFFmpegPlugin/PluginVersion.generated.swift
@@ -1,3 +1,3 @@
 enum CapacitorFFmpegPluginVersion {
-    static let value = "0.0.9"
+    static let value = "0.0.10"
 }

--- a/ios/Tests/CapacitorFFmpegPluginTests/CapacitorFFmpegPluginTests.swift
+++ b/ios/Tests/CapacitorFFmpegPluginTests/CapacitorFFmpegPluginTests.swift
@@ -386,4 +386,35 @@ final class CapacitorFFmpegPluginTests: XCTestCase {
 
         XCTAssertFalse(fileManager.fileExists(atPath: outputURL.path))
     }
+
+    func testConvertAudioWritesWavOutputFromPcmTranscode() throws {
+        let fileManager = FileManager.default
+        let baseURL = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: baseURL, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: baseURL) }
+
+        let inputURL = baseURL.appendingPathComponent("input.wav")
+        let outputURL = baseURL.appendingPathComponent("output.wav")
+        try writeToneWav(to: inputURL)
+        try Data("stale".utf8).write(to: outputURL)
+
+        let result = try waitForAudioConversion(
+            using: CapacitorFFmpeg(),
+            inputPath: inputURL.path,
+            outputPath: outputURL.path,
+            format: "wav",
+            timeout: 5.0
+        )
+
+        switch result {
+        case .success(let convertedAudio):
+            XCTAssertEqual(convertedAudio.format, "wav")
+            XCTAssertEqual(convertedAudio.outputPath, outputURL.absoluteString)
+        case .failure(let error):
+            XCTFail("Expected successful wav conversion, got \(error)")
+        }
+
+        XCTAssertTrue(fileManager.fileExists(atPath: outputURL.path))
+        XCTAssertGreaterThan(try fileManager.attributesOfItem(atPath: outputURL.path)[.size] as? UInt64 ?? 0, 44)
+    }
 }

--- a/ios/Tests/CapacitorFFmpegPluginTests/CapacitorFFmpegPluginTests.swift
+++ b/ios/Tests/CapacitorFFmpegPluginTests/CapacitorFFmpegPluginTests.swift
@@ -234,7 +234,7 @@ final class CapacitorFFmpegPluginTests: XCTestCase {
         defer { try? fileManager.removeItem(at: baseURL) }
 
         let inputURL = baseURL.appendingPathComponent("input.wav")
-        let outputURL = baseURL.appendingPathComponent("output.wav")
+        let outputURL = baseURL.appendingPathComponent("output.mp3")
 
         try writeToneWav(to: inputURL)
 
@@ -242,11 +242,11 @@ final class CapacitorFFmpegPluginTests: XCTestCase {
             try CapacitorFFmpeg().convertAudio(
                 inputPath: inputURL.path,
                 outputPath: outputURL.path,
-                format: "wav"
+                format: "mp3"
             ) { _ in }
         ) { error in
             XCTAssertEqual((error as? FFmpegError)?.code, "INVALID_ARGUMENT")
-            XCTAssertEqual(error.localizedDescription, "Unsupported audio format: wav")
+            XCTAssertEqual(error.localizedDescription, "Audio format mp3 is not yet supported on iOS.")
         }
     }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -11,7 +11,7 @@ export type FFmpegCapabilityStatus = 'available' | 'experimental' | 'unimplement
 export type FFmpegJobState = 'queued' | 'running' | 'completed' | 'failed';
 export type FFmpegProgressState = 'running' | 'completed' | 'failed';
 export type ImageOutputFormat = 'webp' | 'jpeg' | 'png';
-export type AudioOutputFormat = 'm4a';
+export type AudioOutputFormat = 'm4a' | 'mp3' | 'wav' | 'ogg' | 'aac' | 'flac';
 
 export interface FFmpegCapability {
   status: FFmpegCapabilityStatus;
@@ -71,6 +71,12 @@ export interface ConvertAudioOptions {
   inputPath: string;
   outputPath: string;
   format: AudioOutputFormat;
+  /**
+   * Target audio bitrate in bits per second.
+   *
+   * Ignored for lossless outputs such as `wav` and `flac`.
+   */
+  bitrate?: number;
 }
 
 export interface ConvertAudioResult {
@@ -125,8 +131,9 @@ export interface CapacitorFFmpegPlugin extends Plugin {
   /**
    * Convert audio into another container or codec.
    *
-   * iOS currently supports `m4a`.
-   * Android and web currently reject with `UNIMPLEMENTED`.
+   * iOS currently supports `m4a` and `wav`.
+   * Android supports `m4a`, `mp3`, `wav`, `ogg`, `aac`, and `flac`.
+   * Web currently rejects with `UNIMPLEMENTED`.
    */
   convertAudio?(options: ConvertAudioOptions): Promise<ConvertAudioResult>;
 

--- a/src/pluginVersion.ts
+++ b/src/pluginVersion.ts
@@ -1,1 +1,1 @@
-export const PLUGIN_VERSION = '0.0.10';
+export const PLUGIN_VERSION = '0.0.11';

--- a/src/pluginVersion.ts
+++ b/src/pluginVersion.ts
@@ -1,1 +1,1 @@
-export const PLUGIN_VERSION = '0.0.9';
+export const PLUGIN_VERSION = '0.0.10';

--- a/src/pluginVersion.ts
+++ b/src/pluginVersion.ts
@@ -1,1 +1,1 @@
-export const PLUGIN_VERSION = "0.0.10";
+export const PLUGIN_VERSION = '0.0.10';


### PR DESCRIPTION
## Summary
- Expands `AudioOutputFormat` to `m4a | mp3 | wav | ogg | aac | flac` and adds optional `bitrate` on `ConvertAudioOptions`.
- Implements Android `convertAudio()` with FFmpeg (`ffmpeg-kit-16kb`) for all supported formats.
- Extends iOS `convertAudio()` with `wav` export via AVFoundation (`m4a` remains supported; `mp3`, `ogg`, `flac`, and `aac` still return a clear iOS-specific error until native FFmpeg audio lands in the iOS core).

Fixes #3

Supersedes #9.

## Test plan
- [x] `cd android && ./gradlew test`
- [x] `bun run build && bun run test:web`
- [ ] Manual Android: convert `.wav` → `.mp3` and `.ogg` → `.m4a` in the example app
- [ ] Manual iOS: convert input audio → `.wav` and `.m4a`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio conversion is now available on Android with support for `m4a`, `mp3`, `wav`, `ogg`, `aac`, and `flac`.
  * iOS audio conversion now supports both `m4a` and `wav`.
  * Added an optional `bitrate` setting for `convertAudio` (applies to lossy outputs).

* **Bug Fixes**
  * Improved input/output validation to prevent unsupported conversions (e.g., in-place conversions) and provide clearer error messages.

* **Documentation**
  * Updated the supported formats matrix and `convertAudio` API/type definitions to reflect platform capabilities and bitrate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->